### PR TITLE
Fix rpmdeplint --help & Re-tag 1.5 to 2.0rc1

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,7 +18,7 @@ srpm_build_deps:
   - hatch
   - python3-hatch-vcs
 
-upstream_tag_template: rpmdeplint-{version}
+upstream_tag_template: v{version}
 
 jobs:
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,10 +5,6 @@ upstream_project_url: https://github.com/fedora-ci/rpmdeplint
 files_to_sync:
   - rpmdeplint.spec
   - .packit.yaml
-  - src: plans/
-    dest: plans/
-  - src: .fmf/
-    dest: .fmf/
 
 actions:
   create-archive:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,7 @@ repos:
       - id: mypy
         additional_dependencies: [types-requests, types-six]
         exclude: docs/conf.py
+  - repo: https://github.com/packit/pre-commit-hooks
+    rev: v1.2.0
+    hooks:
+      - id: validate-config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,6 @@ repos:
     rev: v1.2.0
     hooks:
       - id: validate-config
+
+ci:
+  autoupdate_schedule: monthly

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,8 +1,9 @@
 Changelog
 ---------
 
-1.6
-~~~
+2.0rc2
+~~~~~~
+
 * Easier development/maintaining:
    * `pre-commit <https://pre-commit.com>`__
    * Use `Packit <https://packit.dev>`__ to:
@@ -23,8 +24,8 @@ Changelog
   Run ``'make -C docs man'`` to build it
   (`related to RHBZ#2221957 <https://bugzilla.redhat.com/show_bug.cgi?id=2221957>`__).
 
-1.5
-~~~
+2.0rc1
+~~~~~~
 * Added yum repository caching which performs regular cleans for files more than
   one week old. This expiry period can be modified with the environment
   variable ``RPMDEPLINT_EXPIRY_SECONDS``.

--- a/plans/smoke.fmf
+++ b/plans/smoke.fmf
@@ -1,5 +1,18 @@
 summary:
-  Basic smoke test
+  Basic tests
+
+discover:
+  how: shell
+  tests:
+
+    - name: /sanity/import
+      test: python3 -c "import rpmdeplint"
+
+    - name: /sanity/help
+      test: rpmdeplint --help
+
+    - name: /sanity/version
+      test: rpmdeplint --version | grep -P "^rpmdeplint \d+\.\d+"
+
 execute:
-  script:
-    - python3 -c "import rpmdeplint"
+  how: tmt

--- a/rpmdeplint.spec
+++ b/rpmdeplint.spec
@@ -1,5 +1,5 @@
 Name:           rpmdeplint
-Version:        1.6
+Version:        2.0
 Release:        %autorelease
 Summary:        Tool to find errors in RPM packages in the context of their dependency graph
 License:        GPL-2.0-or-later

--- a/rpmdeplint/cli.py
+++ b/rpmdeplint/cli.py
@@ -199,7 +199,7 @@ def main():
         subcommand: str, _help: str, subcommand_func: Callable[..., ExitCode]
     ):
         parser_check = subparsers.add_parser(
-            subcommand, help=help, description=subcommand_func.__doc__
+            subcommand, help=_help, description=subcommand_func.__doc__
         )
         add_common_dependency_analyzer_args(parser_check)
         parser_check.set_defaults(func=subcommand_func)


### PR DESCRIPTION
Before I started adding commits to this project, I created a `rpmdeplint-1.5` tag because the previous one was `rpmdeplint-1.4`.

After I released `1.6` I found out that there's a problem that looks like
https://bugzilla.redhat.com/show_bug.cgi?id=1343247#c18
and I realized that the next release after `1.4` was supposed to be `2.0`, not `1.5` probably because of the
- hawkey to libsolv move (36fc40c and others)
- repodata caching/reusing (6f11c37 and others)
- rearrange conflict checking algorithm (5c07a05)

So now I retroactively replaced `rpmdeplint-1.5` with `v2.0rc1` and `rpmdeplint-1.6` with `v2.0rc2`.