### PR TITLE
Make metalinks work on CentOS Stream 9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,7 @@ actions:
     - "python3 -m build --sdist --outdir ."
     - "sh -c 'echo rpmdeplint-$(hatch version).tar.gz'"
   get-current-version:
-    - "hatch version"
+    - bash -c "hatch version | sed 's|^\([[:digit:]]\.[[:digit:]]\)rc|\1~rc|'"
 
 srpm_build_deps:
   - python3-build

--- a/rpmdeplint/repodata.py
+++ b/rpmdeplint/repodata.py
@@ -132,12 +132,14 @@ class Repo:
     @staticmethod
     def get_yumvars() -> dict[str, str]:
         with suppress(ModuleNotFoundError):
-            import dnf.conf
-            import dnf.rpm
+            import dnf
 
-            subst = dnf.conf.Conf().substitutions
-            subst["releasever"] = dnf.rpm.detect_releasever(installroot="")
-            return subst
+            with dnf.Base() as base:
+                subst = base.conf.substitutions
+                with suppress(FileNotFoundError):
+                    if "CentOS Stream" in Path("/etc/redhat-release").read_text():
+                        subst["stream"] = f"{subst['releasever']}-stream"
+                return subst
 
         # Probably not going to work but there's not much else we can do...
         return {


### PR DESCRIPTION
The metalinks in the default `/etc/yum.repos.d/*.repo` on C9S contain `$stream` variable whose value (`9-stream`) I don't know where to get programmatically, hence the 'hack' with reading `/etc/redhat-release`.