### PR TITLE
Exclude dirs known to be owned by many packages from conflict checking

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+dev
+~~~~~~
+
+* Exclude dirs known to be owned by many packages from conflict checking.
+
 2.0
 ~~~~~~
 

--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -273,14 +273,14 @@ class DependencyAnalyzer:
         # This selection matches packages obsoleted
         # by other existing packages in the repo.
         existing_obs_sel = self._select_obsoleted_by(
-            s for s in self.pool.solvables if s.repo.name != "@commandline"
+            s for s in self.pool.solvables_iter() if s.repo.name != "@commandline"
         )
         obsoleted = obs_sel.solvables() + existing_obs_sel.solvables()
         logger.debug(
             "Excluding the following obsoleted packages:\n%s",
             "\n".join(f"  {s}" for s in obsoleted),
         )
-        for solvable in self.pool.solvables:
+        for solvable in self.pool.solvables_iter():
             if solvable in self.solvables:
                 continue  # checked by check-sat command instead
             if solvable in obsoleted:
@@ -413,7 +413,7 @@ class DependencyAnalyzer:
             # a given file is *very slow* (see bug 1465736).
             # Hence this approach, where we visit each solvable and use Python
             # set operations to look for any overlapping filenames.
-            for conflicting in self.pool.solvables:
+            for conflicting in self.pool.solvables_iter():
                 # Conflicts cannot happen between identical solvables and also
                 # between solvables with the same name - such solvables cannot
                 # be installed next to each other.
@@ -474,8 +474,7 @@ class DependencyAnalyzer:
             jobs = self.pool.Selection_all().jobs(Job.SOLVER_UPDATE)
             solver = self.pool.Solver()
             solver.set_flag(solver.SOLVER_FLAG_ALLOW_UNINSTALL, True)
-            solver_problems = solver.solve(jobs)
-            for problem in solver_problems:
+            for problem in solver.solve(jobs):
                 # This is a warning, not an error, because it means there are
                 # some *other* problems with existing packages in the
                 # repository, not our packages under test. But it means our

--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -4,6 +4,7 @@
 # (at your option) any later version.
 
 
+import re
 from collections import defaultdict
 from collections.abc import Iterable
 from logging import getLogger
@@ -326,6 +327,18 @@ class DependencyAnalyzer:
         )
         return {match.str for match in iterator}
 
+    @staticmethod
+    def _remove_dirs_known_to_be_owned_by_many(paths: set[str]) -> set[str]:
+        """
+        Some directories are known to be owned by multiple packages.
+        We don't want to check conflicts upon those, so remove them.
+        """
+        pattern = (
+            r"/usr/lib/(debug/)?\.build-id(/([0-9a-f]{2})?)?|"
+            r"/usr/lib/debug(/usr)?(/bin|/sbin|/lib|/lib64|/\.dwz)?"
+        )
+        return {p for p in paths if not re.fullmatch(pattern, p)}
+
     def _packages_can_be_installed_together(
         self, left: XSolvable, right: XSolvable
     ) -> bool:
@@ -411,7 +424,7 @@ class DependencyAnalyzer:
             # In libsolv, iterating all solvables is fast, and listing all
             # files in a solvable is fast, but finding solvables which contain
             # a given file is *very slow* (see bug 1465736).
-            # Hence this approach, where we visit each solvable and use Python
+            # Hence, this approach, where we visit each solvable and use Python
             # set operations to look for any overlapping filenames.
             for conflicting in self.pool.solvables_iter():
                 # Conflicts cannot happen between identical solvables and also
@@ -419,10 +432,13 @@ class DependencyAnalyzer:
                 # be installed next to each other.
                 if conflicting == solvable or conflicting.name == solvable.name:
                     continue
-                conflict_filenames = filenames.intersection(
-                    self._files_in_solvable(conflicting)
-                )
-                if not conflict_filenames:
+                # Intersect files owned by solvable and conflicting and remove
+                # dirs that are known to be owned by many packages.
+                if not (
+                    conflict_filenames := self._remove_dirs_known_to_be_owned_by_many(
+                        filenames.intersection(self._files_in_solvable(conflicting))
+                    )
+                ):
                     continue
                 if not self._packages_can_be_installed_together(solvable, conflicting):
                     continue


### PR DESCRIPTION
In [find_conflicts()](https://github.com/fedora-ci/rpmdeplint/blob/6c4dac43c5fd23699abea94951086a72bae8a1f0/rpmdeplint/analyzer.py#L433), when we realize that a file/dir is owned also by some other package, we download the other package (its header) to check whether such conflict is permitted (same size/color).

Many [packages contain/own /usr/lib/.build-id/xx](https://fedoraproject.org/wiki/Changes/ParallelInstallableDebuginfo)
That means that previously, basically for every package we checked, we downloaded some other package just to realize that those dirs are the same and hence are not in conflict.

Given that those dirs are generated by the same build tool/service, the chance that there may actually be a real conflict
(e.g. due to different permissions) is IMHO very low so we can skip those and save some time and bandwidth.
We still check files/symlinks in those `/usr/lib/.build-id/xx/`, just not those dirs directly.

IMHO, in an ideal world those dirs would be owned by the `filesystem` package and not individual packages. Until then, we need this.

