### PR TITLE
 If check-upgrade finds a package upgradable by its modular version, ignore it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+    rev: v0.1.6
     hooks:
       - id: ruff-format
       - id: ruff

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,7 @@ dev
 ~~~~~~
 
 * Exclude dirs known to be owned by many packages from conflict checking.
+* If check-upgrade finds a package upgradable by its modular version, skip it.
 
 2.0
 ~~~~~~

--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -508,10 +508,17 @@ class DependencyAnalyzer:
                 if action == transaction.SOLVER_TRANSACTION_IGNORE:
                     continue  # it's kept, so no problem here
                 if action == transaction.SOLVER_TRANSACTION_UPGRADED:
-                    problems.append(
+                    msg = (
                         f"{solvable} would be upgraded by {other} "
                         f"from repo {other.repo.name}"
                     )
+                    # If we find a package upgradable by its modular version, skip it.
+                    # Because a package can be upgraded to its modular version ONLY when
+                    # the module stream is enabled first.
+                    if solvable.name == other.name and ".module" in other.evr:
+                        logger.debug(msg)
+                    else:
+                        problems.append(msg)
                 elif action == transaction.SOLVER_TRANSACTION_OBSOLETED:
                     problems.append(
                         f"{solvable} would be obsoleted by {other} "


### PR DESCRIPTION
Because [a package can be upgraded to its modular version ONLY when the module stream is enabled first](https://docs.fedoraproject.org/en-US/modularity/core-concepts/module-dependency-resolution).

This is a workaround for rpmdeplint not knowing how to do modular filtering.
I don't want to implement it because:
- there's no support for it in `libsolv`, just in `libdnf`
- [modules have been retired in Fedora](https://fedoraproject.org/wiki/Changes/RetireModularity)

https://issues.redhat.com/browse/OSCI-941