### PR TITLE
Remove wrong condition

### DIFF
--- a/rpmdeplint/cli.py
+++ b/rpmdeplint/cli.py
@@ -249,18 +249,15 @@ def main(args=None):
         cmd_list_deps,
     )
     args = parser.parse_args(args)
-    if __name__ == "__main__":
-        # Only configure logging if running as an application
-        # skip if running as a library
-        logging.getLogger().setLevel(logging.DEBUG)
-        log_to_stream(
-            sys.stderr,
-            level=logging.DEBUG
-            if args.debug
-            else logging.ERROR
-            if args.quiet
-            else logging.WARNING,
-        )
+    logging.getLogger().setLevel(logging.DEBUG)
+    log_to_stream(
+        sys.stderr,
+        level=logging.DEBUG
+        if args.debug
+        else logging.ERROR
+        if args.quiet
+        else logging.WARNING,
+    )
 
     validate_common_dependency_analyzer_args(parser, args)
 


### PR DESCRIPTION
the `__name__` is `'__main__'` only when we run directly `cli.py` but is `rpmdeplint.cli` if we run the bin/rpmdeplint or import rpmdeplint.cli