### PR TITLE
Skip modular packages when checking for conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.1.13
     hooks:
       - id: ruff-format
       - id: ruff
@@ -22,7 +22,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         additional_dependencies: [types-requests, types-six]

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -7,6 +7,7 @@ dev
 * Exclude dirs known to be owned by many packages from conflict checking.
 * If check-upgrade finds a package upgradable by its modular version, skip it.
 * Make it possible to run rpmdeplint as a library.
+* Skip modular packages when checking for conflicts.
 
 2.0
 ~~~~~~

--- a/docs/rpmdeplint.rst
+++ b/docs/rpmdeplint.rst
@@ -40,7 +40,7 @@ Options
      --repo=myrepo,/home/me/my_repo
 
    Note that the URL/path should point at a directory containing
-   ``repodata/repomd.xml``. Examples::
+   ``repodata/repomd.xml``.
 
 .. option:: --repos-from-system, -R
 
@@ -112,6 +112,7 @@ check-conflicts
 check-upgrade
   Checks that there are no existing packages in the repositories which would
   upgrade or obsolete the given packages.
+  Modular packages are not considered as candidates.
 
   If this check fails, it means that the package under test will never be
   installed (since the package manager will always pick the newer or obsoleting

--- a/docs/rpmdeplint.rst
+++ b/docs/rpmdeplint.rst
@@ -107,7 +107,8 @@ check-conflicts
   * the file’s checksum, permissions, owner, and group are identical in both
     packages (RPM allows both packages to own the file in this case); or
   * the file’s color is different between the two packages (RPM will
-    silently resolve the conflict in favour of the 64-bit file).
+    silently resolve the conflict in favour of the 64-bit file); or
+  * any (or both) of them is/are a modular package.
 
 check-upgrade
   Checks that there are no existing packages in the repositories which would

--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -501,6 +501,9 @@ class DependencyAnalyzer:
             transaction = solver.transaction()
             problems = []
             for solvable in self.solvables:
+                if ".module" in solvable.evr:
+                    logger.debug("Skipping modular %s", solvable)
+                    continue
                 action = transaction.steptype(
                     solvable, transaction.SOLVER_TRANSACTION_SHOW_OBSOLETES
                 )

--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -419,6 +419,9 @@ class DependencyAnalyzer:
         # solver = self.pool.Solver()
         problems = []
         for solvable in self.solvables:
+            if ".module" in solvable.evr:
+                logger.debug("Skipping modular %s", solvable)
+                continue
             logger.debug("Checking all files in %s for conflicts", solvable)
             filenames = self._files_in_solvable(solvable)
             # In libsolv, iterating all solvables is fast, and listing all
@@ -430,6 +433,8 @@ class DependencyAnalyzer:
                 # Conflicts cannot happen between solvables with the same name,
                 # such solvables cannot be installed next to each other.
                 if conflicting.name == solvable.name:
+                    continue
+                if ".module" in conflicting.evr:
                     continue
                 # Intersect files owned by solvable and conflicting and remove
                 # dirs that are known to be owned by many packages.

--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -427,10 +427,9 @@ class DependencyAnalyzer:
             # Hence, this approach, where we visit each solvable and use Python
             # set operations to look for any overlapping filenames.
             for conflicting in self.pool.solvables_iter():
-                # Conflicts cannot happen between identical solvables and also
-                # between solvables with the same name - such solvables cannot
-                # be installed next to each other.
-                if conflicting == solvable or conflicting.name == solvable.name:
+                # Conflicts cannot happen between solvables with the same name,
+                # such solvables cannot be installed next to each other.
+                if conflicting.name == solvable.name:
                     continue
                 # Intersect files owned by solvable and conflicting and remove
                 # dirs that are known to be owned by many packages.

--- a/rpmdeplint/cli.py
+++ b/rpmdeplint/cli.py
@@ -196,7 +196,7 @@ def validate_common_dependency_analyzer_args(parser, args):
         )
 
 
-def main(args=None):
+def main(args=None) -> ExitCode:
     def add_subparser(
         subcommand: str, _help: str, subcommand_func: Callable[..., ExitCode]
     ):


### PR DESCRIPTION
Previously, we skipped a modular package (with a conflicting file) only if it had the same name (as the non-modular one), now we skip all modular packages.

Similar to b449f354, I don't want to implement modular filtering because:
- there's no support for it in `libsolv`
- modules have been retired in Fedora

https://issues.redhat.com/browse/OSCI-6051