### PR TITLE
conflict checker: skip packages obsoleted by packages under test (#20)

### DIFF
--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -418,6 +418,7 @@ class DependencyAnalyzer:
         """
         # solver = self.pool.Solver()
         problems = []
+        obsoleted = self._select_obsoleted_by(self.solvables).solvables()
         for solvable in self.solvables:
             if ".module" in solvable.evr:
                 logger.debug("Skipping modular %s", solvable)
@@ -433,6 +434,9 @@ class DependencyAnalyzer:
                 # Conflicts cannot happen between solvables with the same name,
                 # such solvables cannot be installed next to each other.
                 if conflicting.name == solvable.name:
+                    continue
+                # ignore any existing packages the update will replace
+                if conflicting in obsoleted:
                     continue
                 if ".module" in conflicting.evr:
                     continue


### PR DESCRIPTION
As explained in issue #20, when checking for conflicts, it's not enough to skip only existing packages with the same name as the one they are being checked against. We should skip all existing packages that the set of packages being tested would replace.

Fortunately, we already have `_select_obsoleted_by` to do this exact job, so let's just use it here.

We keep the existing 'skip if the names are the same' check to avoid generating confusing results if the update under test contains a package with the same name as an existing package but with a *lower* EVR. This is wrong, but we should leave it to be caught by other checks; handling it here would give a rather confusing failure about file conflicts between the two packages, which the packager might not understand.