### PR TITLE
Add an argument to always download all headers in conflict check

### DIFF
--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -132,6 +132,7 @@ class DependencyAnalyzer:
         repos: Iterable,
         packages: Iterable[str],
         arch: Optional[str] = None,
+        allconflicts: bool = False,
     ):
         """
         :param repos: An iterable of :py:class:`rpmdeplint.repodata.Repo` instances
@@ -142,6 +143,7 @@ class DependencyAnalyzer:
 
         self.pool = Pool()
         self.pool.setarch(arch)
+        self.allconflicts = allconflicts
 
         # List of :py:class:`solv.Solvable` to be tested
         # (corresponding to *packages* parameter)
@@ -458,7 +460,7 @@ class DependencyAnalyzer:
                             f"which is also provided by {conflicting}"
                         )
                         problems.append(msg)
-                    if conflicting not in self.solvables:
+                    if not self.allconflicts and conflicting not in self.solvables:
                         # For each filename we are checking, we only want to
                         # check at most *one* package from the remote
                         # repositories. This is purely an optimization to save

--- a/rpmdeplint/cli.py
+++ b/rpmdeplint/cli.py
@@ -138,7 +138,9 @@ def dependency_analyzer_from_args(args):
         repos.extend(Repo.from_yum_config())
     repos.extend(args.repos)
 
-    return DependencyAnalyzer(repos, list(args.rpms), arch=args.arch)
+    return DependencyAnalyzer(
+        repos, list(args.rpms), arch=args.arch, allconflicts=args.allconflicts
+    )
 
 
 def repo(value: str) -> Repo:
@@ -183,6 +185,11 @@ def add_common_dependency_analyzer_args(parser):
         dest="arch",
         default=None,
         help="Limit dependency resolution to ARCH packages [default: any arch]",
+    )
+    parser.add_argument(
+        "--allconflicts",
+        action="store_true",
+        help="Check all packages with a given filename for conflicts",
     )
 
 


### PR DESCRIPTION
The conflict check tries to 'save bandwidth' by only checking one remote package for each potentially-conflicting filename. This of course means that if the first checked remote package is OK (because the files match, or the colors differ), but *another* remote package would not be OK, we hide the problem.

This adds an argument which disables the 'bandwidth saving' feature and always checks all remote packages that contain each potentially-conflicting filename. It makes the check take longer and use more bandwidth, but it won't hide problems.