### PR TITLE
packit create-archive: fix filename discovery, fix tests for RPM systemd user integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,7 +9,7 @@ files_to_sync:
 actions:
   create-archive:
     - "python3 -m build --sdist --outdir ."
-    - "sh -c 'echo rpmdeplint-$(hatch version).tar.gz'"
+    - "sh -c 'ls -1 rpmdeplint*.tar.gz'"
   get-current-version:
     - bash -c "hatch version | sed 's|^\([[:digit:]]\.[[:digit:]]\)rc|\1~rc|'"
 

--- a/tests/acceptance/test_check_conflicts.py
+++ b/tests/acceptance/test_check_conflicts.py
@@ -228,6 +228,7 @@ def test_conflict_not_ignored_if_contents_match_but_perms_differ(request, dir_se
         sourceFile=SourceFile("thing", "content\n"),
         owner="apache",
     )
+    different_owner.add_provides("user(apache)")
     different_owner.make()
 
     different_group = SimpleRpmBuild("z", "0.1", "1", ["i386"])
@@ -236,6 +237,7 @@ def test_conflict_not_ignored_if_contents_match_but_perms_differ(request, dir_se
         sourceFile=SourceFile("thing", "content\n"),
         group="apache",
     )
+    different_group.add_provides("group(apache)")
     different_group.make()
 
     def cleanUp():


### PR DESCRIPTION
CI jobs are failing because, for some reason, the two commands in this action disagree about how many characters to shorten a git commit hash to:

```
2026-03-18 21:52:55.333 logging.py        INFO   Successfully built rpmdeplint-2.0.post1.dev20+g65eeb972c.tar.gz
2026-03-18 21:52:55.363 commands.py       DEBUG  Command: sh -c echo rpmdeplint-$(hatch version).tar.gz
2026-03-18 21:52:55.578 logging.py        INFO   rpmdeplint-2.0.post1.dev20+g65eeb97.tar.gz
```

note the file `build` uses creates with first 9 characters of the commit hash (`65eeb972c`), but `hatch version` is apparently only giving us the first 7 (`65eeb97`) so we look for the wrong filename.

Also, after that, tests fail on F43+ because some dummy packages that use specific owners/groups for files need to provide `user(foo)` and/or `group(foo)` since https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers happened.