### PR TITLE
fix: update COPYING to drop obsolete FSF postal address

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.15
     hooks:
       - id: ruff-format
       - id: ruff-check
@@ -19,7 +19,8 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+    # v2.0 dropped Python 3.9 support
+    rev: v1.20.2
     hooks:
       - id: mypy
         additional_dependencies: [types-requests, types-six]

--- a/COPYING
+++ b/COPYING
@@ -1,8 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -304,8 +303,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 


### PR DESCRIPTION
Replace the outdated Franklin Street boilerplate with the current FSF GPL-2.0 text so rpmlint `incorrect-fsf-address` passes on packages.
