### PR TITLE
check-conflicts: ignore packages replaced by packages under test (#34)

### DIFF
--- a/rpmdeplint/analyzer.py
+++ b/rpmdeplint/analyzer.py
@@ -420,6 +420,12 @@ class DependencyAnalyzer:
         """
         problems = []
 
+        # This selection matches packages obsoleted by our packages under test
+        obsoleted = self._select_obsoleted_by(self.solvables).solvables()
+        logger.debug(
+            "Excluding the following obsoleted packages:\n%s",
+            "\n".join(f"  {s}" for s in obsoleted),
+        )
         # Collect files from packages under test
         test_solvable_files: dict[XSolvable, set[str]] = {}
         all_test_files: set[str] = set()
@@ -448,6 +454,11 @@ class DependencyAnalyzer:
         pool_overlapping: dict[XSolvable, frozenset[str]] = {}
         for pool_solvable in self.pool.solvables_iter():
             if ".module" in pool_solvable.evr:
+                continue
+            if pool_solvable in obsoleted:
+                # we don't want to report "conflicts" in packages that will
+                # be replaced by packages from the set under test
+                # https://github.com/fedora-ci/rpmdeplint/issues/34
                 continue
             if overlap := self._files_in_solvable(pool_solvable) & all_test_files:
                 pool_overlapping[pool_solvable] = frozenset(overlap)


### PR DESCRIPTION
We should not report (and fail on) "conflicts" between one package from the set of packages under test, and a package from the base repository which would be replaced by *another* of the packages under test.

See the case in the issue, where an update contained a new fmt package and an fmt11 package which contained files that were also present in the old fmt package in the base repository. Because the new fmt package did not contain those same files, we ought not to report a conflict and fail.